### PR TITLE
Prime CSS-declared assets before applying styles

### DIFF
--- a/src/module/artist.js
+++ b/src/module/artist.js
@@ -7,7 +7,7 @@
 // - Keyframe-driven animations
 // - Pseudo-class painting (:hover, :focus, :active)
 
-import { getAsset } from './utils.js';
+import { gatherAssets, getAsset } from './utils.js';
 import Cell from './cell.js';
 import { animateLerp, KeyFrameAnimationLerp } from './Train.js';
 import * as THREE from 'three';
@@ -463,6 +463,7 @@ function _apply_rule(rule, object, _chosenOne = null) {
  * @param {Cell} cell
  */
 export function paintConvict(convictElm, cell) {
+  gatherAssets();
   const convict = cell._allConvictsByDom.get(convictElm);
   if (convict) {
     _apply_rule(convictElm, convict);
@@ -500,6 +501,7 @@ export function paintExtraCell(muse) {
  * @param {Cell} muse
  */
 export function paintCell(muse) {
+  gatherAssets();
   for (const obj of muse.classyConvicts) {
     for (const cls of getObjectClassSelectors(obj)) {
       const rule = getCSSRule(`.${cls}`);
@@ -519,6 +521,7 @@ export function paintCell(muse) {
  * @param {THREE.Object3D} muse
  */
 export function paintSpecificMuse(muse) {
+  gatherAssets();
   const extra = muse.userData.extraParams || [];
 
   getObjectClassSelectors(muse).forEach(cls => {

--- a/src/module/cell.js
+++ b/src/module/cell.js
@@ -8,7 +8,7 @@
 // - Per-frame update callbacks
 
 import * as THREE from 'three';
-import { getClassMap } from './utils.js';
+import { gatherAssets, getClassMap } from './utils.js';
 import {
   paintCell,
   paintConvict,
@@ -106,6 +106,9 @@ class Cell {
     cellElm.addEventListener('dblclick', this._boundDoubleClick);
     cellElm.addEventListener('contextmenu', this._boundContextMenu);
 
+    // prime CSS-declared assets before first style apply
+    gatherAssets();
+
     // initial paint
     paintCell(this);
 
@@ -116,6 +119,7 @@ class Cell {
       this._pendingStyleRepaint = true;
       requestAnimationFrame(() => {
         this._pendingStyleRepaint = false;
+        gatherAssets();
         paintCell(this);
         this._repaintKnownConvicts();
       });
@@ -278,6 +282,7 @@ class Cell {
     this._pendingStyleRepaint = true;
     requestAnimationFrame(() => {
       this._pendingStyleRepaint = false;
+      gatherAssets();
       paintCell(this);
       this._repaintKnownConvicts();
     });

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -205,6 +205,13 @@ function gatherAssetRules() {
 }
 
 /**
+ * Prime CSS-declared asset entries before style application.
+ */
+export function gatherAssets() {
+  gatherAssetRules();
+}
+
+/**
  * Get or load an asset by name.
  *
  * Built-ins (auto-registered on first use):


### PR DESCRIPTION
### Motivation
- Prevent race conditions where CSS-driven custom properties reference assets that haven't been registered yet, by ensuring CSS-declared assets are discovered before style rules are applied.

### Description
- Added a new exported `gatherAssets()` helper in `src/module/utils.js` that calls the existing `gatherAssetRules()` to prime the asset map.
- Updated `src/module/artist.js` to import `gatherAssets` and call it at the start of `paintConvict`, `paintCell`, and `paintSpecificMuse` so assets are available before rules are applied.
- Updated `src/module/cell.js` to import `gatherAssets` and invoke it before the initial `paintCell` and before full repaints triggered by style changes.

### Testing
- Ran the production build via `npm run build:lib`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a210d75c0083319806230d8cd8c1e0)